### PR TITLE
Fix development API port configuration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8082
+VITE_API_BASE_URL=http://localhost:8080


### PR DESCRIPTION
# Fix development API port configuration

## Summary
Fixed a port mismatch in the local development environment configuration. The `.env.development` file was configured to connect to `localhost:8082`, but the backend service actually runs on `localhost:8080`, causing connection failures during local development.

**Change**: Updated `VITE_API_BASE_URL` in `.env.development` from `http://localhost:8082` to `http://localhost:8080`

This was discovered while verifying the local development startup process - the browser console showed `net::ERR_CONNECTION_REFUSED` errors when trying to fetch venue data from the API.

## Review & Testing Checklist for Human
- [ ] **Verify backend port**: Confirm the swimlane backend actually runs on port 8080 when started with `./gradlew quarkusDev`
- [ ] **Test full local development workflow**: Start both backend and frontend, verify API connectivity and data loading in browser
- [ ] **Check for other port references**: Ensure no other config files or documentation reference port 8082

**Recommended test plan**: 
1. Start backend: `cd ~/repos/swimlane && ./gradlew quarkusDev`
2. Start frontend: `cd ~/repos/swimlane-ui && npm run dev` 
3. Open http://localhost:5173 and verify venue data loads without console errors

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    envdev[".env.development<br/>(VITE_API_BASE_URL)"]:::major-edit
    constants["src/constants.ts<br/>(API_BASE_URL import)"]:::context
    axios["src/lib/axios.ts<br/>(axios baseURL config)"]:::context
    backend["Backend Service<br/>(localhost:8080)"]:::context
    
    envdev -->|"provides env var"| constants
    constants -->|"exports constant"| axios
    axios -->|"HTTP requests to"| backend
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
This is a simple but critical fix for local development. The backend has always run on port 8080 (as configured in the Quarkus application), but the frontend was misconfigured to connect to 8082.

**Link to Devin run**: https://app.devin.ai/sessions/40fe54715d544d1586c0aa9345bcbded  
**Requested by**: Chris S (@cpsnowden)